### PR TITLE
upgrade to Guard v1.1

### DIFF
--- a/lib/guard/delayed.rb
+++ b/lib/guard/delayed.rb
@@ -56,7 +56,7 @@ module Guard
     end
 
     # Called on file(s) modifications
-    def run_on_change(paths)
+    def run_on_changes(paths)
       restart
     end
 


### PR DESCRIPTION
Renaming run_on_change(paths) to run_on_changes(path), which is relevant to upgrading to Guard v1.1: https://github.com/guard/guard/wiki/Upgrade-guide-for-existing-guards-to-Guard-v1.1
