### PR TITLE
Include license in gemspec

### DIFF
--- a/guard-delayed.gemspec
+++ b/guard-delayed.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://rubygems.org/gems/guard-delayed'
   s.summary     = %q{guard gem for delayed_job}
   s.description = %q{Guard::Delayedjob automatically starts/stops/restarts delayed_job}
+  s.license     = "MIT"
 
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = "guard-delayed"


### PR DESCRIPTION
This helps automated tools find the license.

I'm suggesting MIT because it's guard's license.
