### PR TITLE
Fix gem dependencies for Guard 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1 (2015-02-19)
+
+* Modified the dependencies to support Guard 2
+
 ## 0.3.0 (2014-11-27)
 
 * Upgraded to work with Guard 2.

--- a/guard-delayed.gemspec
+++ b/guard-delayed.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 2.2'
   s.rubyforge_project = "guard-delayed"
 
-  s.add_dependency 'guard', '~> 0'
-  s.add_dependency 'delayed_job', '~> 0'
+  s.add_dependency 'guard', '>= 0.3', '< 3.0'
+  s.add_dependency 'delayed_job', '>= 0'
 
-  s.add_development_dependency 'bundler', '~> 0'
-  s.add_development_dependency 'rspec', '~> 0'
-  s.add_development_dependency 'guard-rspec', '~> 0'
-  s.add_development_dependency 'guard-bundler', '~> 0'
+  s.add_development_dependency 'bundler', '> 1.0.10'
+  s.add_development_dependency 'rspec', '> 2.5.0'
+  s.add_development_dependency 'guard-rspec', '> 0.2.0'
+  s.add_development_dependency 'guard-bundler', '> 0.1.1'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/guard/delayed/version.rb
+++ b/lib/guard/delayed/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module DelayedVersion
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
Hey,
This is a fix in reference to https://github.com/suranyami/guard-delayed/issues/11

Essentially, I reverted all the dependencies to the way they were for version 0.2.1 and then changed the guard dependency to disallow > 3.0
You may or may not want to add constraints to some of the other dependencies... but please not ~> 0 which seems to not work :smile: 