### PR TITLE
gemspec: drop rubyforge_project, it is EOL

### DIFF
--- a/guard-delayed.gemspec
+++ b/guard-delayed.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.required_rubygems_version = '~> 3'
-  s.rubyforge_project = "guard-delayed"
 
   s.add_dependency "guard", "~> 2"
   s.add_dependency "guard-compat", "~> 1.1"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.